### PR TITLE
Promise returned by .end() will reject when transition is interrupted…

### DIFF
--- a/src/ui/log-controller.ts
+++ b/src/ui/log-controller.ts
@@ -584,6 +584,7 @@ export default class LogController {
       .duration(this.options.transitionDuration)
       .style('flex', '0 0 0%')
       .end()
+      .catch(() => ({})) // happens on interrupt
       .finally(() => {
         selection.remove();
         this.debounce(this.postUpdateTracks);
@@ -667,6 +668,7 @@ export default class LogController {
       .duration(this.options.transitionDuration)
       .style('flex', d => `${d.options.width}`)
       .end()
+      .catch(() => ({})) // happens on interrupt
       .finally(() => this.debounce(this.postUpdateTracks));
   }
 


### PR DESCRIPTION
…. Added noop-handler to swallow this rejection.