### PR TITLE
Boundary value fix in data filter

### DIFF
--- a/src/utils/data-helper.ts
+++ b/src/utils/data-helper.ts
@@ -90,9 +90,10 @@ export default class DataHelper {
       const within = pt[0] >= dmin && pt[0] <= dmax;
       if (within) return true;
 
-      const prevLessThanMax = (i - 1 >= 0 && datapoints[i - 1][0] < dmax);
-      const nextGreaterThanMin = (i + 1 < datapoints.length && datapoints[i + 1][0] > dmin);
-      return (prevLessThanMax && nextGreaterThanMin);
+      const crossingMin = pt[0] < dmin && i + 1 < datapoints.length && datapoints[i + 1][0] > dmin;
+      const crossingMax = pt[0] > dmax && i - 1 >= 0 && datapoints[i - 1][0] < dmax;
+
+      return crossingMin || crossingMax;
     });
   }
 

--- a/test/data-helper.spec.ts
+++ b/test/data-helper.spec.ts
@@ -44,6 +44,20 @@ describe('DataHelper', () => {
     ]);
   });
 
+  it('should not filter out boundary values within the domain', () => {
+    expect(DataHelper.filterData([[3, 20], [4, 10]], [3.1, 3.9], 0)).to.eql([
+      [3, 20], [4, 10],
+    ]);
+
+    expect(DataHelper.filterData([[3, 20], [4, 10]], [3, 3.9], 0)).to.eql([
+      [3, 20], [4, 10],
+    ]);
+
+    expect(DataHelper.filterData([[3, 20], [4, 10]], [3.1, 4], 0)).to.eql([
+      [3, 20], [4, 10],
+    ]);
+  });
+
   it('should be able to resample data points to a given ratio', () => {
     const data : PlotData = range(0, 10000, 1).map(d => [d, d]);
     expect(DataHelper.resample(data, 1)).to.eql(data);


### PR DESCRIPTION
In our plots, we ask for data covered by the current view. With sparsely populated data, even if outside points are included in the data provided to plot, they are not displayed correctly by the graph tracks (filtered out).

Added unit tests to reveal this issue and proposed a fix.