### PR TITLE
✨ Added option to paint dots on LinePlot for isolated points

### DIFF
--- a/src/plots/interfaces.ts
+++ b/src/plots/interfaces.ts
@@ -117,6 +117,10 @@ export interface LinePlotOptions extends PlotOptions {
    * @example [2, 3] // Draw 2, skip 3 pixels
    */
   dashWrapped?: number[],
+  /**
+   * If enabled, points surrounded by non-defined values will be displayed as a dot
+   */
+  showIsolatedPoints?: boolean,
 }
 
 /**

--- a/src/plots/line-plot.ts
+++ b/src/plots/line-plot.ts
@@ -51,6 +51,32 @@ export default class LinePlot extends Plot<LinePlotOptions> {
       this.plotWrapped(ctx, lineFunction);
     }
 
+    if (options.showIsolatedPoints) {
+      const arcL = Math.PI * 2;
+
+      ctx.fillStyle = options.color;
+
+      plotdata
+        .filter((t, i) => {
+          if (!options.defined(t[1], t[0])) return false;
+
+          const prev = plotdata[i - 1]?.[1];
+          const next = plotdata[i + 1]?.[1];
+
+          if (i === 0) return !options.defined(next);
+          if (i === plotdata.length - 1) return !options.defined(prev);
+          return !options.defined(prev) && !options.defined(next);
+        })
+        .forEach(d => {
+          ctx.beginPath();
+
+          if (options.horizontal) ctx.arc(scale(d[0]), xscale(d[1]), 1, 0, arcL);
+          else ctx.arc(xscale(d[1]), scale(d[0]), 1, 0, arcL);
+
+          ctx.fill();
+        });
+    }
+
     ctx.restore();
   }
 


### PR DESCRIPTION
Added a showIsolatedPoints flag to LinePlotOptions interface.
Allows single points surrounded by not-defined values in LinePlots to be shown as dots

Disabled:
![image](https://github.com/equinor/videx-wellog/assets/101267373/11333a77-63be-4b46-b4e2-1bbce05e0d07)

Enabled:
![image](https://github.com/equinor/videx-wellog/assets/101267373/2acdf54f-4bee-4217-b7aa-82064ff15918)
