### PR TITLE
Added discrete version of distribution track

### DIFF
--- a/examples/storybook/stories/shared/mock-data.js
+++ b/examples/storybook/stories/shared/mock-data.js
@@ -18,11 +18,11 @@ export const ex3 = {
 export const ex4 = async (formationLength=10) => {
   const names = ['Utsira Fm.', 'Frigg Fm.', 'Skade Fm.', 'Tor Fm.', 'Draupne Fm.', 'Hod Fm.'];
   const colors = [
-    {r:0,g:200,b:200}, 
-    {r:2,g:200,b:2}, 
-    {r:53,g:53,b:240}, 
-    {r:224,g:254,b:84}, 
-    {r:175,g:15,b:115}, 
+    {r:0,g:200,b:200},
+    {r:2,g:200,b:2},
+    {r:53,g:53,b:240},
+    {r:224,g:254,b:84},
+    {r:175,g:15,b:115},
     {r:116,g:116,b:116}
   ];
 
@@ -58,21 +58,21 @@ export const ex4_xlarge = async () => {
 export const ex4_fix = async () => {
   const names = ['Utsira Fm.', 'Frigg Fm.', 'Skade Fm.', 'Tor Fm.', 'Draupne Fm.', 'Hod Fm.'];
   const colors = [
-    {r:0,g:200,b:200}, 
-    {r:2,g:200,b:2}, 
-    {r:53,g:53,b:240}, 
-    {r:224,g:254,b:84}, 
-    {r:175,g:15,b:115}, 
+    {r:0,g:200,b:200},
+    {r:2,g:200,b:2},
+    {r:53,g:53,b:240},
+    {r:224,g:254,b:84},
+    {r:175,g:15,b:115},
     {r:116,g:116,b:116}
   ];
   const facies = [
-    {id:1,from:10,to:40}, 
-    {id:2,from:40,to:90}, 
-    {id:3,from:90,to:240}, 
+    {id:1,from:10,to:40},
+    {id:2,from:40,to:90},
+    {id:3,from:90,to:240},
     {id:4,from:240,to:340},
-    {id:5,from:340,to:600}, 
-    {id:0,from:600,to:670}, 
-    {id:2,from:670,to:720}, 
+    {id:5,from:340,to:600},
+    {id:0,from:600,to:670},
+    {id:2,from:670,to:720},
     {id:5,from:720,to:930}
   ];
   const arr = [];
@@ -224,4 +224,32 @@ export const ex7 = async (useShortName=false) => {
 // Facies Track using short Name
 export const ex7_shortName = async() => {
   return ex7(true);
+};
+
+export const exampleDistributionData = () => {
+  const components = ['carbonate', 'shale', 'sand'];
+  const data = [];
+
+  for (let depth = 200; depth <= 1000; depth += 10) {
+    let remainingValue = 100;
+
+    const composition = components.map((key, index) => {
+      // For the last component, assign full remaining value
+      if (index === components.length - 1) {
+        return { key, value: remainingValue };
+      }
+
+      const value = parseFloat((Math.random() * remainingValue).toFixed(2));
+      remainingValue -= value;
+
+      return { key, value };
+    });
+
+    data.push({
+      depth,
+      composition,
+    });
+  }
+
+  return data;
 };

--- a/examples/storybook/stories/shared/tracks.js
+++ b/examples/storybook/stories/shared/tracks.js
@@ -5,13 +5,22 @@ import {
   graphLegendConfig,
   LegendHelper,
   scaleLegendConfig,
+  distributionLegendConfig,
+  DistributionTrack,
 } from '../../../../src';
 import {
   ex1,
   ex2,
   ex3,
   ex4_large,
+  exampleDistributionData,
 } from './mock-data';
+
+const distributionComponents = {
+  'carbonate': { color: 'red' },
+  'sand': { color: 'green' },
+  'shale': { color: 'blue' },
+};
 
 export default (delayLoading = false) => {
   const tracks = [
@@ -117,7 +126,20 @@ export default (delayLoading = false) => {
         },
       }],
     }),
-    new StackedTrack(5, {label:"Formation", showLines: false, labelRotation: -90, data: ex4_large}),
+    new StackedTrack(5, {
+      label:"Formation",
+      showLines: false,
+      labelRotation: -90,
+      data: ex4_large,
+    }),
+    new DistributionTrack(6, {
+      label: 'Distribution',
+      abbr: 'Dst',
+      data: exampleDistributionData,
+      legendConfig: distributionLegendConfig(distributionComponents),
+      components: distributionComponents,
+      discreteHeight: 5,
+    }),
   ];
 
   if (delayLoading) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@equinor/videx-wellog",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@equinor/videx-wellog",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
+        "@equinor/videx-math": "^1.1.0",
         "d3-array": "^3.2.0",
         "d3-scale": "^4.0.2",
         "d3-selection": "^3.0.0",
@@ -16,6 +17,7 @@
         "d3-zoom": "^3.0.0"
       },
       "devDependencies": {
+        "@rollup/plugin-node-resolve": "^15.2.3",
         "@types/chai": "^4.2.11",
         "@types/d3-array": "^3.0.3",
         "@types/d3-scale": "^4.0.2",
@@ -40,7 +42,6 @@
         "rimraf": "^3.0.2",
         "rollup": "^2.79.0",
         "rollup-plugin-copy": "^3.3.0",
-        "rollup-plugin-node-resolve": "^5.2.0",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-typescript2": "^0.34.0",
@@ -598,6 +599,11 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@equinor/videx-math": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@equinor/videx-math/-/videx-math-1.1.0.tgz",
+      "integrity": "sha512-nOooZbUpVunXHBlfkUHs9Srh7zomtTlfJPsfp9u/9P0Yp/dBnbg4va2X0LHuN1tVBllYQc7P9boelyoK3dSxCA=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -1588,6 +1594,65 @@
         "node": ">=10"
       }
     },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+      "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.2.1",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve/node_modules/@rollup/pluginutils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve/node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true
+    },
+    "node_modules/@rollup/plugin-node-resolve/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -1763,6 +1828,12 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
     "node_modules/@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -1873,15 +1944,6 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
-    },
-    "node_modules/@types/resolve": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -2659,12 +2721,15 @@
       "dev": true
     },
     "node_modules/builtin-modules": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cacache": {
@@ -5397,6 +5462,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-callable": {
@@ -9990,23 +10070,6 @@
         "node": ">=8.3"
       }
     },
-    "node_modules/rollup-plugin-node-resolve": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
-      "integrity": "sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-node-resolve.",
-      "dev": true,
-      "dependencies": {
-        "@types/resolve": "0.0.8",
-        "builtin-modules": "^3.1.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.11.1",
-        "rollup-pluginutils": "^2.8.1"
-      },
-      "peerDependencies": {
-        "rollup": ">=1.11.0"
-      }
-    },
     "node_modules/rollup-plugin-postcss": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-4.0.2.tgz",
@@ -12108,6 +12171,11 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@equinor/videx-math": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@equinor/videx-math/-/videx-math-1.1.0.tgz",
+      "integrity": "sha512-nOooZbUpVunXHBlfkUHs9Srh7zomtTlfJPsfp9u/9P0Yp/dBnbg4va2X0LHuN1tVBllYQc7P9boelyoK3dSxCA=="
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -12863,6 +12931,45 @@
         }
       }
     },
+    "@rollup/plugin-node-resolve": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+      "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.2.1",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+          "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0",
+            "estree-walker": "^2.0.2",
+            "picomatch": "^2.3.1"
+          }
+        },
+        "@types/resolve": {
+          "version": "1.20.2",
+          "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+          "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
+        }
+      }
+    },
     "@rollup/pluginutils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -13031,6 +13138,12 @@
         "@types/d3-selection": "*"
       }
     },
+    "@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -13141,15 +13254,6 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
-    },
-    "@types/resolve": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -13678,9 +13782,9 @@
       "dev": true
     },
     "builtin-modules": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true
     },
     "cacache": {
@@ -15737,6 +15841,15 @@
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.3.0"
       }
     },
     "is-callable": {
@@ -19081,19 +19194,6 @@
         "fs-extra": "^8.1.0",
         "globby": "10.0.1",
         "is-plain-object": "^3.0.0"
-      }
-    },
-    "rollup-plugin-node-resolve": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
-      "integrity": "sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==",
-      "dev": true,
-      "requires": {
-        "@types/resolve": "0.0.8",
-        "builtin-modules": "^3.1.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.11.1",
-        "rollup-pluginutils": "^2.8.1"
       }
     },
     "rollup-plugin-postcss": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@equinor/videx-wellog",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "license": "MIT",
   "description": "Visualisation components for wellbore log data",
   "repository": "https://github.com/equinor/videx-wellog",
@@ -37,7 +37,8 @@
     "predocs": "rimraf docs",
     "docs": "typedoc --out docs src",
     "postdocs": "copyfiles .nojekyll docs",
-    "lint": "npx eslint src --ext ts --color --format table"
+    "lint": "npx eslint src --ext ts --color --format table",
+    "storybook": "cd examples/storybook && npm run storybook"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",
@@ -64,7 +65,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.79.0",
     "rollup-plugin-copy": "^3.3.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
+    "@rollup/plugin-node-resolve": "^15.2.3",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.34.0",
@@ -74,6 +75,7 @@
     "typescript": "^4.8.3"
   },
   "dependencies": {
+    "@equinor/videx-math": "^1.1.0",
     "d3-array": "^3.2.0",
     "d3-scale": "^4.0.2",
     "d3-selection": "^3.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import typescript from 'rollup-plugin-typescript2';
-import resolve from 'rollup-plugin-node-resolve';
+import resolve from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
 import autoprefixer from 'autoprefixer';
 import postcss from 'rollup-plugin-postcss';
@@ -37,7 +37,7 @@ export default [
     external: [...Object.keys(pkg.dependencies || {})],
     plugins: [
       typescript({ tsconfig: './tsconfig.json' }),
-      resolve({ modulesOnly: true }),
+      resolve({ extensions: ['.mjs', '.js', '.json', '.node', '.ts'] }),
       terser({ mangle: false }),
     ],
     onwarn,
@@ -51,7 +51,7 @@ export default [
     },
     plugins: [
       typescript({ tsconfig: './tsconfig.json' }),
-      resolve({ modulesOnly: true }),
+      resolve({ extensions: ['.mjs', '.js', '.json', '.node', '.ts'] }),
       terser({ mangle: false }),
     ],
     onwarn,

--- a/src/plots/dot-plot.ts
+++ b/src/plots/dot-plot.ts
@@ -25,7 +25,7 @@ export default class DotPlot extends Plot<DotPlotOptions> {
 
     ctx.fillStyle = options.color;
     const arcL = Math.PI * 2;
-    plotdata.forEach(d => {
+    plotdata?.forEach(d => {
       if (!options.defined(d[1], d[0])) return;
 
       ctx.beginPath();

--- a/src/tracks/distribution/distribution-legend.ts
+++ b/src/tracks/distribution/distribution-legend.ts
@@ -1,0 +1,92 @@
+import { select } from 'd3-selection';
+import { clamp, lerp } from '@equinor/videx-math';
+import LegendHelper, {
+  LegendBounds,
+  LegendConfig,
+  LegendOnUpdateFunction,
+} from '../../utils/legend-helper';
+import { D3Selection } from '../../common/interfaces';
+import { DistributionComponents } from './interfaces';
+
+const Padding = 20;
+const LabelPadding = 10;
+
+function renderDistributionLabels(g: D3Selection, bounds: LegendBounds, data: DistributionComponents, horizontal: boolean = false) : void {
+  const { width, height, left = 0, top = 0 } = bounds;
+
+  // Get components in distribution, return if missing
+  const components = data && Object.entries(data);
+  if (!components) return;
+
+  const textSize = Math.min(12, width / 3);
+  const squareSize = textSize * 0.75;
+
+  // Find width-span and height to draw labels along. These are relative to track orientation, not screen orientation.
+  const wMin = left + Padding;
+  const wMax = width - Padding;
+  const h = top + height - squareSize;
+
+  // Calculate how many labels we can stack
+  const labelSpace = width - Padding * 2;
+  const labelCount = clamp(Math.floor(labelSpace / (textSize + LabelPadding)), 1, components.length);
+
+  for (let i = 0; i < labelCount; i++) {
+    const [label, component] = components[i];
+    const color = component.color;
+
+    // Center a single label; distribute multiple labels evenly.
+    const t = labelCount === 1 ? 0.5 : i / (labelCount - 1);
+
+    // Define x and y for label. This is where the colored square is drawn
+    let x: number, y: number;
+    if (horizontal) {
+      y = lerp(wMin, wMax, t);
+      x = h;
+    } else {
+      x = lerp(wMin, wMax, t);
+      y = h;
+    }
+
+    // Append colored square
+    g.append('rect')
+      .attr('x', x - squareSize * 0.5)
+      .attr('y', y - squareSize * 0.5)
+      .attr('width', squareSize)
+      .attr('height', squareSize)
+      .attr('fill', color);
+
+    // Labels are displayed behind the square
+    const transform = horizontal
+      ? `translate(${x - squareSize},${y})`
+      : `translate(${x},${y - squareSize})rotate(90)`;
+
+    const lbl = g.append('text')
+      .attr('transform', transform)
+      .attr('font-size', `${textSize}px`)
+      .attr('dominant-baseline', 'middle')
+      .style('text-anchor', 'end');
+    lbl.text(label);
+
+    // TODO: Show short form?
+    /*
+    const bbox = lbl.node().getBBox();
+    if (bbox.width > height * 0.8) {
+      lbl.text(label);
+    }
+    */
+  }
+}
+
+export function distributionLegendConfig(data: DistributionComponents) : LegendConfig {
+  const onLegendUpdate: LegendOnUpdateFunction = (elm, bounds, track) => {
+    const g = select(elm);
+    g.selectAll('*').remove();
+    renderDistributionLabels(
+      g,
+      bounds,
+      data,
+      track.options.horizontal,
+    );
+  };
+  return LegendHelper.basicLegendSvgConfig(() => 3, onLegendUpdate);
+}

--- a/src/tracks/distribution/distribution-track.ts
+++ b/src/tracks/distribution/distribution-track.ts
@@ -1,0 +1,147 @@
+import { scaleLinear, ScaleLinear } from 'd3-scale';
+import { select } from 'd3-selection';
+import SvgTrack from '../svg-track';
+import {
+  CompositionEntry,
+  DistributionData,
+  DistributionTrackOptions,
+} from './interfaces';
+import { OnMountEvent, OnRescaleEvent, OnUpdateEvent } from '../interfaces';
+import { setAttrs } from '../../utils';
+
+/** Track for visualising distribution of data. */
+export class DistributionTrack extends SvgTrack<DistributionTrackOptions> {
+  xscale: ScaleLinear<number, number>;
+  discreteHeight: number;
+
+  /** Override of onMount from base class. */
+  onMount(event: OnMountEvent) {
+    super.onMount(event);
+
+    const {
+      options,
+      loader,
+    } = this;
+
+    this.xscale = scaleLinear().domain([0, 1]);
+    this.discreteHeight = options.discreteHeight || 10;
+
+    if (options.data) {
+      const showLoader = options.showLoader ?? Boolean(loader);
+
+      if (showLoader && typeof (options.data) === 'function') {
+        this.loadData(options.data, showLoader);
+      } else {
+        this.data = options.data;
+      }
+    }
+  }
+
+  /** Override of onUpdate from base class. */
+  onUpdate(event: OnUpdateEvent) {
+    super.onUpdate(event);
+    if (this.options.horizontal) {
+      this.xscale.range([0, this.elm.clientHeight]);
+    } else {
+      this.xscale.range([0, this.elm.clientWidth]);
+    }
+    this.plot();
+  }
+
+  /** Override of onRescale from base class. */
+  onRescale(event: OnRescaleEvent) {
+    super.onRescale(event);
+    this.plot();
+  }
+
+  plot() {
+    const {
+      plotGroup: g,
+      scale: yscale,
+      xscale,
+      data,
+      options,
+      discreteHeight,
+    } = this;
+
+    if (!g) return;
+
+    // Clear visuals if 'data' is undefined or empty
+    if (!data?.length) {
+      g.selectAll('g.area').remove();
+      return;
+    }
+
+    // Get the current visible domain
+    const [min, max] = yscale.domain();
+
+    // Filter data based on the visible domain
+    const visibleData = data.filter((d: DistributionData) => d.depth + discreteHeight >= min && d.depth - discreteHeight <= max);
+
+    // Transform depth
+    const transformedData: DistributionData = visibleData.map((d: DistributionData) => ({
+      depth: yscale(d.depth),
+      composition: d.composition,
+    }));
+
+    const selection = g.selectAll('g.area').data(transformedData, (d: DistributionData) => d.depth);
+
+    const horizontalTransform = (d: DistributionData) => `translate(${d.depth - discreteHeight / 2}, 0)`;
+    const verticalTransform = (d: DistributionData) => `translate(0, ${d.depth - discreteHeight / 2})`;
+    const transform = options.horizontal ? horizontalTransform : verticalTransform;
+
+    selection.attr('transform', transform);
+
+    const getRectGeom = (x0: number, x1: number, color: string) => (options.horizontal
+      // Horizontal Rectangle
+      ? {
+        x: 0,
+        y: xscale(x0),
+        width: discreteHeight,
+        height: xscale(x1),
+        fill: color,
+      }
+      // Vertical Rectangle
+      : {
+        x: xscale(x0),
+        y: 0,
+        width: xscale(x1),
+        height: discreteHeight,
+        fill: color,
+      }
+    );
+
+    const updateGroup = (group: any, composition: CompositionEntry[]) => {
+      let cumulativeWidth = 0;
+
+      composition.forEach(({ key, value }) => {
+        const width = (value / 100);
+        const color = options.components[key]?.color;
+        const rectGeom = getRectGeom(cumulativeWidth, cumulativeWidth + width, color || 'black');
+        cumulativeWidth += width;
+        group.append('rect').call(setAttrs, rectGeom);
+      });
+    };
+
+    // Update existing areas
+    // eslint-disable-next-line func-names
+    selection.each(function (d: DistributionData) {
+      const group = select(this);
+      group.selectAll('rect').remove(); // Clear previous rects
+      updateGroup(group, d.composition);
+    });
+
+    // Create new areas
+    const newAreas = selection.enter().append('g')
+      .classed('area', true)
+      .attr('transform', transform);
+
+    // eslint-disable-next-line func-names
+    newAreas.each(function (d: DistributionData) {
+      const group = select(this);
+      updateGroup(group, d.composition);
+    });
+
+    selection.exit().remove();
+  }
+}

--- a/src/tracks/distribution/index.ts
+++ b/src/tracks/distribution/index.ts
@@ -1,0 +1,2 @@
+export { DistributionTrack } from './distribution-track';
+export { distributionLegendConfig } from './distribution-legend';

--- a/src/tracks/distribution/interfaces.ts
+++ b/src/tracks/distribution/interfaces.ts
@@ -1,0 +1,46 @@
+import { TrackOptions } from '../interfaces';
+
+export interface DistributionTrackOptions extends TrackOptions {
+  /**
+   * Data for all plots in the track. May be of any type or a function or promise
+   * returning data. The plots will need to have a data accessor function defined, that
+   * can pick the data it needs from this value.
+   */
+  data?: Promise<any> | Function | any,
+
+  /** Whether or not to show the loader (if configured) */
+  showLoader?: boolean,
+
+  /** Orientation of track. Default is false or unset (vertical). */
+  horizontal?: boolean,
+
+  /** The height to use for discrete values. */
+  discreteHeight: number,
+
+  /** List of distribution components. */
+  components?: DistributionComponents,
+}
+
+/** Represents a collection of distribution components. */
+export interface DistributionComponents {
+  [key: string]: {
+    /** Color of the element. */
+    color: string;
+  };
+}
+
+export interface DistributionData {
+  /** Depth of distribution. */
+  depth: number,
+
+  /** Composition of the distribution. */
+  composition: CompositionEntry[];
+}
+
+export interface CompositionEntry {
+  /** Name of the entry. */
+  key: string;
+
+  /** Percentage value of the entry. */
+  value: number;
+}

--- a/src/tracks/graph/graph-track.ts
+++ b/src/tracks/graph/graph-track.ts
@@ -66,7 +66,7 @@ export default class GraphTrack extends CanvasTrack<GraphTrackOptions> {
     } = this;
 
     if (options.data) {
-      const showLoader = options.showLoader === undefined ? !!loader : options.showLoader;
+      const showLoader = options.showLoader ?? Boolean(loader);
 
       if (showLoader && typeof (options.data) === 'function') {
         this.loadData(options.data, showLoader);

--- a/src/tracks/index.ts
+++ b/src/tracks/index.ts
@@ -6,3 +6,4 @@ export { default as HtmlTrack } from './html-track';
 export * from './graph';
 export * from './scale';
 export * from './stack';
+export * from './distribution';

--- a/src/utils/legend-helper.ts
+++ b/src/utils/legend-helper.ts
@@ -49,13 +49,12 @@ export default class LegendHelper {
    * Renders a simple rotated text label that is scaled to fit bounds
    */
   static renderBasicVerticalSvgLabel(g: D3Selection, bounds: LegendBounds, label: string, abbr: string, horizontal: boolean = false) : void {
-    const { width: w, height: h, left, top } = bounds;
+    const { width, height, left = 0, top = 0 } = bounds;
 
-    const y = (top || 0) + h * 0.9;
-    const textSize = Math.min(12, Math.min(w, 40) / 3);
-    const x = horizontal
-      ? (left || 0) + Math.max(0, (w / 2) + (textSize / 3))
-      : (left || 0) + Math.max(0, (w / 2) - (textSize / 3));
+    const y = top + height * 0.9;
+    const x = left + Math.max(0, (width / 2));
+
+    const textSize = Math.min(12, Math.min(width, 40) / 3);
 
     const transform = horizontal
       ? `translate(${y},${x})`
@@ -64,11 +63,12 @@ export default class LegendHelper {
     const lbl = g.append('text')
       .attr('transform', transform)
       .attr('font-size', `${textSize}px`)
+      .attr('dominant-baseline', 'middle')
       .style('text-anchor', 'end');
     lbl.text(label);
 
     const bbox = lbl.node().getBBox();
-    if (bbox.width > h * 0.8) {
+    if (bbox.width > height * 0.8) {
       lbl.text(abbr || label);
     }
   }
@@ -78,7 +78,7 @@ export default class LegendHelper {
    * a rotated label legend.
    */
   static basicVerticalLabel(label: string, abbr: string) : LegendConfig {
-    function onLegendUpdate(elm, bounds, track) {
+    const onLegendUpdate: LegendOnUpdateFunction = (elm, bounds, track) => {
       const g = select(elm);
       g.selectAll('*').remove();
       LegendHelper.renderBasicVerticalSvgLabel(
@@ -88,7 +88,7 @@ export default class LegendHelper {
         abbr || track.options.abbr,
         track.options.horizontal,
       );
-    }
+    };
     return LegendHelper.basicLegendSvgConfig(() => 3, onLegendUpdate);
   }
 }


### PR DESCRIPTION
Added distribution track and legend. Distribution will eventually support interpolation, but will only display as discrete for now.

Other notes:
- Bumped version to 0.10.0
- Updated @rollup/plugin-node-resolve
- Updated legend-helper with better logic for centering
- Added script to package.json to run storybook from main project folder: "npm run storybook"