### PR TITLE
ci: add node parameters

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,6 +18,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          registry-url: https://registry.npmjs.org
+          always-auth: true
+          token: ${{secrets.NPM_TOKEN}}
       - name: npm install, build, and test
         run: |
           npm ci


### PR DESCRIPTION
- Add node parameters to get rid of `authorization needed` error