### PR TITLE
ci: add npm-publish action

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,9 +18,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: https://registry.npmjs.org
-          always-auth: true
-          token: ${{secrets.NPM_TOKEN}}
       - name: npm install, build, and test
         run: |
           npm ci
@@ -30,7 +27,7 @@ jobs:
         env:
           CI: true
       - name: Publish to NPM
-        env:
-          NPM_TOKEN: ${{secrets.NPM_TOKEN}}
-        run: |
-          npm publish
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{secrets.NPM_TOKEN}}
+          provenance: true


### PR DESCRIPTION
Got 404 on the last, so trying with using the [JSDevTools/npm-publish](https://github.com/JS-DevTools/npm-publish) action instead