### PR TITLE
fix: Add meaningful tooltip to track title

### DIFF
--- a/examples/storybook/stories/shared/tracks.js
+++ b/examples/storybook/stories/shared/tracks.js
@@ -51,6 +51,7 @@ export default (delayLoading = false) => {
     }),
     new GraphTrack(2, {
       label: 'Pointy',
+      tooltip: 'a graph with points',
       abbr: 'Pt',
       data: ex1,
       scale: 'linear',

--- a/src/tracks/interfaces.ts
+++ b/src/tracks/interfaces.ts
@@ -34,11 +34,15 @@ export interface OnRescaleEvent extends TrackEvent {
 
 export interface TrackOptions {
   /**
-   * Label to use in title if used with TrackGrouop
+   * Label to use in title if used with TrackGroup
    */
   label?: string,
   /**
-   * Short label to use in title if used with TrackGrouop
+   * Tooltip to show when mouse hovers over track title if used with TrackGroup
+   */
+  tooltip?: string,
+  /**
+   * Short label to use in title if used with TrackGroup
    */
   abbr?: string,
   /**

--- a/src/ui/log-controller.ts
+++ b/src/ui/log-controller.ts
@@ -640,7 +640,7 @@ export default class LogController {
       setProps(titleDiv, {
         attrs: d => ({
           class: 'track-title',
-          title: d.options.label || d.id,
+          title: d.options.tooltip || d.options.label || d.id,
         }),
         styles: {
           [attr.size]: `${titleHeight}px`,


### PR DESCRIPTION
Currently the tooltip displayed when hovering over a track title is the text that is displayed as title. This is not very informative sometimes  and we would like to have the option to display a different text as tooltip.

![image](https://github.com/user-attachments/assets/236b3f48-90c2-4d54-a6d4-77dce4b527a8)
