### PR TITLE
fix/4006 handle differential plot data separately, instead of merging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@equinor/videx-wellog",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@equinor/videx-wellog",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@equinor/videx-math": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@equinor/videx-wellog",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "description": "Visualisation components for wellbore log data",
   "repository": "https://github.com/equinor/videx-wellog",

--- a/src/plots/differential-plot.ts
+++ b/src/plots/differential-plot.ts
@@ -187,46 +187,44 @@ export default class DifferentialPlot extends Plot<DifferentialPlotOptions> {
       }
     }
 
-    const merged = DataHelper.mergeDataSeries(scaleddata[0] || [], scaleddata[1] || []);
-
     // render correlation areas
     const areaFunction1 = area<Triplet<number>>().context(ctx);
     const areaFunction2 = area<Triplet<number>>().context(ctx);
 
     if (horizontal) {
       areaFunction1
-        .defined(d => def(d[1], d[0]) && def(d[2], d[0]))
+        .defined(d => def(d[1], d[0]))
         .y0(max)
         .y1(d => d[1])
         .x(d => d[0]);
 
       areaFunction2
-        .defined(d => def(d[1], d[0]) && def(d[2], d[0]))
+        .defined(d => def(d[1], d[0]))
         .y0(min)
-        .y1(d => d[2])
+        .y1(d => d[1])
         .x(d => d[0]);
     } else {
       areaFunction1
-        .defined(d => def(d[1], d[0]) && def(d[2], d[0]))
+        .defined(d => def(d[1], d[0]))
         .x0(min)
         .x1(d => d[1])
         .y(d => d[0]);
 
       areaFunction2
-        .defined(d => def(d[1], d[0]) && def(d[2], d[0]))
+        .defined(d => def(d[1], d[0]))
         .x0(max)
-        .x1(d => d[2])
+        .x1(d => d[1])
         .y(d => d[0]);
     }
 
     ctx.save();
     ctx.globalAlpha = fillOpacity || 0.5;
     ctx.beginPath();
-    areaFunction2(merged);
+    areaFunction2(scaleddata[1]);
     ctx.clip();
 
     ctx.beginPath();
-    areaFunction1(merged);
+    areaFunction1(scaleddata[0]);
     ctx.fillStyle = serie1.fill;
     ctx.fill();
     ctx.restore();
@@ -242,11 +240,11 @@ export default class DifferentialPlot extends Plot<DifferentialPlotOptions> {
     ctx.save();
     ctx.globalAlpha = fillOpacity || 0.5;
     ctx.beginPath();
-    areaFunction1(merged);
+    areaFunction1(scaleddata[0]);
     ctx.clip();
 
     ctx.beginPath();
-    areaFunction2(merged);
+    areaFunction2(scaleddata[1]);
     ctx.fillStyle = serie2.fill;
     ctx.fill();
     ctx.restore();


### PR DESCRIPTION
[Fixes #4006](https://github.com/equinor/mad-project-rep/issues/4006)

Explanation for the fix is [here](https://github.com/equinor/mad-project-rep/issues/4006#issuecomment-2949129698)

Specific examples of the DENSITY and POROSITY issue can be found [here](http://localhost:5001/#/operations/wellbore/NO_34/10-O-3_AH) and [here](http://localhost:5001/#/operations/wellbore/NO_30/4-A-13_A), but the change affects all differential plot types, so there should be no impact on the storybook examples or functioning density examples that use [RHOB and NPHI](http://localhost:5001/#/operations/wellbore/NO_34/10-C-16).
