### PR TITLE
chore: add commit linter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
         patterns:
           - "*"
     commit-message:
-      prefix: "[github-actions] "
+      prefix: chore(actions)
 
   - package-ecosystem: npm
     directories:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,20 @@
+name: Lint Pull Request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions: {}
+
+jobs:
+  lint-pr:
+    name: Lint PR Title
+    permissions:
+      contents: read
+    uses: equinor/ops-actions/.github/workflows/commitlint.yml@c096742f0e74f7edbccc01c38020050894425506 # 9.32.1
+    with:
+      message: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Related to equinor/rep-fe-iac#100

- Add commit linter workflow `lint-pr.yml`
- Add Dependabot prefix for GitHub actions to make sure Dependabot doesn't fail the commit linter